### PR TITLE
PR: Moodboard Tab

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
         deploy:
             resources:
                 limits:
-                    cpus: '2'
-                    memory: 2g
+                    cpus: '4'
+                    memory: 4g
         volumes:
             - ./package.json:/app/package.json
             - ./node_modules:/app/node_modules

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   profile       Profile?
   comment       Comment[]
   affiliation   Affiliation[]
+  moodboard     Moodboard[]
 
   @@map("users")
 }
@@ -99,4 +100,14 @@ model Affiliation {
   user             User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("affiliations")
+}
+
+model Moodboard {
+  id             String @id @default(cuid())
+  moodboardImage String
+  userId         String
+  profileId      String
+  user           User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("moodboards")
 }

--- a/src/actions/moodboards/add-moodboards.ts
+++ b/src/actions/moodboards/add-moodboards.ts
@@ -1,0 +1,25 @@
+'use server';
+import * as z from 'zod';
+import { db } from '@/lib/prisma';
+import { addMoodboardSchema } from '@/types/types';
+import { revalidatePath } from 'next/cache';
+
+export const addMoodboard = async(formData: FormData) => {
+    const profileId = formData.get('profileId');
+	const userId = formData.get('userId');
+	const moodboardImage = formData.get('moodboardImage');
+
+    await db.moodboard.create({
+        data: {
+            profileId: profileId as string,
+            userId: userId as string,
+            moodboardImage: moodboardImage as string,
+        },
+    });
+
+    revalidatePath(`/profile/${profileId}`);
+
+    return {
+        success: true,
+    };
+}

--- a/src/app/(protected)/profile/[id]/page.tsx
+++ b/src/app/(protected)/profile/[id]/page.tsx
@@ -45,6 +45,21 @@ async function getAffiliations(profileId: string) {
 	return modifiedAffiliations;
 }
 
+async function getMoodboards(profileId: string) {
+	const moodboards = await db.moodboard.findMany({
+		where: {
+			profileId: profileId,
+		},
+	});
+
+	const modifiedMoodboards = moodboards.map((moodboard) => ({
+		...moodboard,
+		user: undefined,
+	}));
+
+	return modifiedMoodboards
+}
+
 const Profile = async ({ params }: any) => {
 	// Profile page for example is a server component
 	const profile = await getUserById(params.id);
@@ -56,16 +71,18 @@ const Profile = async ({ params }: any) => {
 
 	const affiliations = await getAffiliations(params.id);
 
+	const moodboards = await getMoodboards(params.id);
+
 	return (
 		<div className='w-full h-full grid grid-cols-3 grid-rows-2'>
 			<div className='row-span-2 p-4'>
 				<ProfileCard profile={profile}></ProfileCard>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
-				<Showcase params={params} affiliations={affiliations}></Showcase>
+				<Showcase params={params} affiliations={affiliations} moodboards={moodboards}></Showcase>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
-				<Feeds params={params} comments={comments}></Feeds>
+				{/* <Feeds params={params} comments={comments}></Feeds> */}
 			</div>
 		</div>
 	);

--- a/src/app/(protected)/profile/[id]/page.tsx
+++ b/src/app/(protected)/profile/[id]/page.tsx
@@ -82,7 +82,7 @@ const Profile = async ({ params }: any) => {
 				<Showcase params={params} affiliations={affiliations} moodboards={moodboards}></Showcase>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
-				{/* <Feeds params={params} comments={comments}></Feeds> */}
+				<Feeds params={params} comments={comments}></Feeds>
 			</div>
 		</div>
 	);

--- a/src/components/profile/Showcase.tsx
+++ b/src/components/profile/Showcase.tsx
@@ -8,7 +8,7 @@ import { FaHandshake } from 'react-icons/fa';
 
 import { FaSignsPost } from 'react-icons/fa6';
 
-const Showcase = ({ params, affiliations }: any) => {
+const Showcase = ({ params, affiliations, moodboards }: any) => {
 	const [activeTab, setActiveTab] = useState('moodboard');
 
 	const handleTabClick = (tab: React.SetStateAction<string>) => {
@@ -47,7 +47,7 @@ const Showcase = ({ params, affiliations }: any) => {
 				</a>
 			</div>
 			<div className='w-[69rem] h-[23rem] p-4'>
-				{activeTab === 'moodboard' && <Moodboard></Moodboard>}
+				{activeTab === 'moodboard' && <Moodboard params={params} moodboards={moodboards}></Moodboard>}
 				{activeTab === 'affiliation' && <Affiliation params={params} affiliations={affiliations}></Affiliation>}
 				{activeTab === 'posts' && <Posts></Posts>}
 			</div>

--- a/src/components/profile/ui/Showcase/Moodboard.tsx
+++ b/src/components/profile/ui/Showcase/Moodboard.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { MoodboardConfig } from '@/config/site-config';
 import Image from 'next/image';
+import { useSession } from 'next-auth/react';
+import { TMoodboard } from '@/types/types';
+import { addMoodboard } from '@/actions/moodboards/add-moodboards';
 
-const Moodboard = () => {
+
+const Moodboard = ({ params, affiliations }: any) => {
+	const session = useSession();
 	return (
 		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-4 auto-rows-[328px] overflow-auto'>

--- a/src/components/profile/ui/Showcase/Moodboard.tsx
+++ b/src/components/profile/ui/Showcase/Moodboard.tsx
@@ -9,7 +9,7 @@ import { addMoodboard } from '@/actions/moodboards/add-moodboards';
 const Moodboard = ({ params, moodboards }: any) => {
 	const session = useSession();
 	return (
-		<div className='w-full h-full overflow-auto relative'>
+		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-4 auto-rows-[328px] overflow-auto'>
 				{moodboards.length === 0 ? (
 					<div className='w-full h-full flex flex-row items-start justify-start'>
@@ -23,7 +23,7 @@ const Moodboard = ({ params, moodboards }: any) => {
 					))
 				)}
 			</div>
-			<div className='w-full flex flex-row items-end justify-between absolute bottom-0'>
+			<div className='w-full flex flex-row items-end justify-between'>
 			{(moodboards.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
 					<div className='flex-1'>
 					<button className="btn rounded-xl"

--- a/src/components/profile/ui/Showcase/Moodboard.tsx
+++ b/src/components/profile/ui/Showcase/Moodboard.tsx
@@ -6,18 +6,22 @@ import { TMoodboard } from '@/types/types';
 import { addMoodboard } from '@/actions/moodboards/add-moodboards';
 
 
-const Moodboard = ({ params, affiliations }: any) => {
+const Moodboard = ({ params, moodboards }: any) => {
 	const session = useSession();
 	return (
 		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-4 auto-rows-[328px] overflow-auto'>
-				{MoodboardConfig.images.map((item, index) => {
-					return (
-						<div key={index} className='col-span-1 m-4 rounded-xl relative overflow-hidden'>
-							<Image className='object-cover rounded-t-xl' src={`${item.image}`} alt='' fill />
+			{moodboards.length === 0 ? (
+					<div className='w-full h-full flex flex-row items-center justify-start'>
+						<h1 className='text-4xl font-bold'>No Moodboards.</h1>
+					</div>
+				) : (
+				moodboards.map((moodboard: TMoodboard) => (
+						<div key={moodboard.id} className='col-span-1 m-4 rounded-xl relative overflow-hidden'>
+							<Image className='object-cover rounded-t-xl' src={`${moodboard.moodboardImage}`} alt='' fill />
 						</div>
-					);
-				})}
+				))
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/profile/ui/Showcase/Moodboard.tsx
+++ b/src/components/profile/ui/Showcase/Moodboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { MoodboardConfig } from '@/config/site-config';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
@@ -9,19 +9,63 @@ import { addMoodboard } from '@/actions/moodboards/add-moodboards';
 const Moodboard = ({ params, moodboards }: any) => {
 	const session = useSession();
 	return (
-		<div className='w-full h-full overflow-auto'>
+		<div className='w-full h-full overflow-auto relative'>
 			<div className='w-full h-full grid grid-cols-4 auto-rows-[328px] overflow-auto'>
-			{moodboards.length === 0 ? (
-					<div className='w-full h-full flex flex-row items-center justify-start'>
+				{moodboards.length === 0 ? (
+					<div className='w-full h-full flex flex-row items-start justify-start'>
 						<h1 className='text-4xl font-bold'>No Moodboards.</h1>
 					</div>
 				) : (
-				moodboards.map((moodboard: TMoodboard) => (
+					moodboards.map((moodboard: TMoodboard) => (
 						<div key={moodboard.id} className='col-span-1 m-4 rounded-xl relative overflow-hidden'>
 							<Image className='object-cover rounded-t-xl' src={`${moodboard.moodboardImage}`} alt='' fill />
 						</div>
-				))
+					))
 				)}
+			</div>
+			<div className='w-full flex flex-row items-end justify-between absolute bottom-0'>
+			{(moodboards.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
+					<div className='flex-1'>
+					<button className="btn rounded-xl"
+						onClick={() => (document.getElementById('moodboard_modal') as HTMLDialogElement).showModal()}>
+						Add a moodboard
+					</button>
+					<dialog id="moodboard_modal" className="modal">
+						<div className="modal-box rounded-xl">
+							<form method="dialog">
+								{/*Closes the modal box*/}
+								<button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+							</form>
+							<form action={addMoodboard} className='px-2 py-2 flex flex-col gap-4 items-end size-full'>
+								<label className='form-control size-full'>
+									<input type='hidden' name='profileId' value={params.id} />
+									<input type='hidden' name='userId' value={session.data?.user.id!} />
+									<input
+										className="input input-bordered w-full rounded-xl whitespace-pre-line"
+										type="text"
+										name='moodboardImage'
+										placeholder="Enter your moodboard unsplash URL"
+									/>
+								</label>
+								<button
+									className='btn btn-outline rounded-xl btn-sm'
+									type='submit'
+									onClick={() => {
+										(document.getElementById('moodboard_modal') as HTMLDialogElement).close();
+									}}>
+									Add Moodboard
+								</button>
+							</form>
+						</div>
+					</dialog>
+				</div>
+			) : null)}
+				<div className="join flex flex-row">
+					<button className="join-item btn btn-active">1</button>
+					<button className="join-item btn">2</button>
+					<button className="join-item btn">3</button>
+					<button className="join-item btn">4</button>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -57,3 +57,17 @@ export type TAffiliation = {
 	verified: string;
 	userId: string;
 }
+
+export const addMoodboardSchema = z.object({
+	profileId: z.string().min(1, 'Require profileId'),
+	userId: z.string().min(1, 'Require userId'),
+});
+
+export type TAddMoodboardSchema = z.infer<typeof addMoodboardSchema>;
+
+export type TMoodboard = {
+	id: string;
+	moodboardImage: string;
+	userId: string;
+	profileId: string;
+}


### PR DESCRIPTION
# Overview
Completed implementation of the basic adding mood board functionality for the Moodboard tab

## User Stories
- As a user, I want to see the profile page of other users, so that I can see their mood boards
- As a developer, I want to give users the basic functionality to add mood boards, so that other users viewing their profile can see their mood boards
#16 

## Features
- Allows user to add a mood board to themselves
- Allows users to view each others mood boards
- A user viewing another user doesn't have the ability to add an mood board for somebody else, only the authorized user.
- Modal for form
- Fetches data via the server component

## Changes
- Created new Moodboard table
- Made design changes
- Defined a fetch affiliation method within the profile page
- Included params for each function definition to take and pass props between components from the Profile page

## Known Issues or Bugs
- Used Prop drilling, code will have to be refactored to reduce the complexity of the code-base and improve performance

## Snapshots
https://github.com/brandonhach/rep/assets/114207613/92f27b4a-74d7-4cdb-b855-0d8814878bc3

## Let me know if I missed anything!