### PR TITLE
PR: Trade Posts Tab

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,17 +28,18 @@ enum UserRole {
 model User {
   id            String          @id @default(cuid())
   name          String?
-  image         String         @default("https://images.unsplash.com/photo-1534528741775-53994a69daeb?q=80&w=1364&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D")
+  image         String          @default("https://images.unsplash.com/photo-1534528741775-53994a69daeb?q=80&w=1364&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D")
   country       String?
   email         String          @unique
   emailVerified DateTime?
   password      String?
-  avatar        Bytes? @db.ByteA 
+  avatar        Bytes?          @db.ByteA
   accounts      Account[]
-  role          UserRole @default(USER)
-  createdAt     DateTime @default(now())
+  role          UserRole        @default(USER)
+  createdAt     DateTime        @default(now())
   profile       Profile?
   comment       Comment[]
+  tradePost     TradePost[]
 
   @@map("users")
 }
@@ -55,9 +56,9 @@ model Account {
   scope             String?
   id_token          String?
   session_state     String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
  
   @@id([provider, providerAccountId])
 }
@@ -84,4 +85,19 @@ model Comment {
   updatedAt DateTime @updatedAt
 
   @@map("comments")
+}
+
+model TradePost {
+  id          String   @id @default(cuid())
+  title       String
+  image       String
+  description String
+  price       String
+  postType    String
+  userId      String
+  profileId   String
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  @@map("posts")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ enum UserRole {
 model User {
   id            String          @id @default(cuid())
   name          String?
-  image         String?
+  image         String         @default("https://images.unsplash.com/photo-1534528741775-53994a69daeb?q=80&w=1364&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D")
   country       String?
   email         String          @unique
   emailVerified DateTime?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,7 +97,6 @@ model TradePost {
   userId      String
   profileId   String
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  @@map("posts")
+
+  @@map("tradePosts")
 }

--- a/src/actions/signup.ts
+++ b/src/actions/signup.ts
@@ -12,7 +12,7 @@ export const Signup = async (values: z.infer<typeof signUpSchema>) => {
 		return { error: 'Invalid fields' };
 	}
 
-	const { email, password, username } = validatedFields.data;
+	const { email, password, name } = validatedFields.data;
 
 	const existingUser = await getUserByEmail(email);
 	if (existingUser) return { error: 'Email already in use!' };
@@ -20,7 +20,7 @@ export const Signup = async (values: z.infer<typeof signUpSchema>) => {
 
 	await db.user.create({
 		data: {
-			username,
+			name,
 			email,
 			password: hashedPassword,
 		},

--- a/src/actions/trade-posts/add-trade-post.ts
+++ b/src/actions/trade-posts/add-trade-post.ts
@@ -13,7 +13,6 @@ export const addTradePost = async (formData: FormData) => {
     const price = formData.get('price');
     const postType = formData.get('postType');
 
-
     await db.tradePost.create({
         data: {
             profileId: profileId as string,

--- a/src/actions/trade-posts/add-trade-post.ts
+++ b/src/actions/trade-posts/add-trade-post.ts
@@ -10,6 +10,9 @@ export const addTradePost = async (formData: FormData) => {
     const title = formData.get('title');
     const image = formData.get('image');
     const description = formData.get('description');
+    const price = formData.get('price');
+    const postType = formData.get('postType');
+
 
     await db.tradePost.create({
         data: {
@@ -18,6 +21,8 @@ export const addTradePost = async (formData: FormData) => {
             title: title as string,
             image: image as string,
             description: description as string,
+            price: price as string,
+            postType:postType as string,
         },
     });
 

--- a/src/actions/trade-posts/add-trade-post.ts
+++ b/src/actions/trade-posts/add-trade-post.ts
@@ -1,0 +1,27 @@
+'use server';
+import * as z from 'zod';
+import { db } from '@/lib/prisma';
+import { addTradePostSchema } from '@/types/types';
+import { revalidatePath } from 'next/cache';
+
+export const addTradePost = async (formData: FormData) => {
+    const profileId = formData.get('profileId');
+    const userId = formData.get('userId');
+    const content = formData.get('content');
+
+    await db.tradePost.create({
+        data: {
+            profileId: profileId as string,
+            userId: userId as string,
+            title: title as string,
+            image: image as string,
+            description: description as string,
+        },
+    });
+
+    revalidatePath(`/profile/${profileId}`); // profile check for data change and reloads
+
+    return {
+        success: true,
+    };
+};

--- a/src/actions/trade-posts/add-trade-post.ts
+++ b/src/actions/trade-posts/add-trade-post.ts
@@ -7,7 +7,9 @@ import { revalidatePath } from 'next/cache';
 export const addTradePost = async (formData: FormData) => {
     const profileId = formData.get('profileId');
     const userId = formData.get('userId');
-    const content = formData.get('content');
+    const title = formData.get('title');
+    const image = formData.get('image');
+    const description = formData.get('description');
 
     await db.tradePost.create({
         data: {

--- a/src/actions/trade-posts/delete-trade-post.ts
+++ b/src/actions/trade-posts/delete-trade-post.ts
@@ -1,0 +1,22 @@
+'use server';
+import * as z from 'zod';
+import { db } from '@/lib/prisma';
+import { deleteTradePostSchema } from '@/types/types';
+import { revalidatePath } from 'next/cache';
+
+export const deleteTradePost = async (formData: FormData) => {
+    const id = formData.get('id')
+    const profileId = formData.get('profileId');
+
+    await db.tradePost.delete({
+        where: {
+            id: id as string,
+        },
+    });
+
+    revalidatePath(`/profile/${profileId}`); // profile check for data change and reloads
+
+    return {
+        success: true,
+    };
+};

--- a/src/actions/trade-posts/edit-trade-post.ts
+++ b/src/actions/trade-posts/edit-trade-post.ts
@@ -1,14 +1,18 @@
 'use server';
 import * as z from 'zod';
 import { db } from '@/lib/prisma';
-import { addTradePostSchema } from '@/types/types';
+import { editradePostSchema } from '@/types/types';
 import { revalidatePath } from 'next/cache';
 import {undefined} from "zod";
 
 export const editTradePost = async (formData: FormData) => {
     const profileId = formData.get('profileId');
     const userId = formData.get('userId');
-    const content = formData.get('content');
+    const title = formData.get('title');
+    const image = formData.get('image');
+    const description = formData.get('description');
+    const price = formData.get('price');
+    const postType = formData.get('postType');
 
     await db.tradePost.update({
         data: {
@@ -17,6 +21,8 @@ export const editTradePost = async (formData: FormData) => {
             title: title as string,
             image: image as string,
             description: description as string,
+            price: price as string,
+            postType:postType as string,
         }
     });
 

--- a/src/actions/trade-posts/edit-trade-post.ts
+++ b/src/actions/trade-posts/edit-trade-post.ts
@@ -1,7 +1,7 @@
 'use server';
 import * as z from 'zod';
 import { db } from '@/lib/prisma';
-// import { editradePostSchema } from '@/types/types';
+import { editTradePostSchema } from '@/types/types';
 import { revalidatePath } from 'next/cache';
 
 export const editTradePost = async (formData: FormData) => {

--- a/src/actions/trade-posts/edit-trade-post.ts
+++ b/src/actions/trade-posts/edit-trade-post.ts
@@ -1,11 +1,11 @@
 'use server';
 import * as z from 'zod';
 import { db } from '@/lib/prisma';
-import { editradePostSchema } from '@/types/types';
+// import { editradePostSchema } from '@/types/types';
 import { revalidatePath } from 'next/cache';
-import {undefined} from "zod";
 
 export const editTradePost = async (formData: FormData) => {
+    const id = formData.get('id')
     const profileId = formData.get('profileId');
     const userId = formData.get('userId');
     const title = formData.get('title');
@@ -15,6 +15,9 @@ export const editTradePost = async (formData: FormData) => {
     const postType = formData.get('postType');
 
     await db.tradePost.update({
+        where: {
+            id: id as string,
+        },
         data: {
             profileId: profileId as string,
             userId: userId as string,

--- a/src/actions/trade-posts/edit-trade-post.ts
+++ b/src/actions/trade-posts/edit-trade-post.ts
@@ -1,0 +1,29 @@
+'use server';
+import * as z from 'zod';
+import { db } from '@/lib/prisma';
+import { addTradePostSchema } from '@/types/types';
+import { revalidatePath } from 'next/cache';
+import {undefined} from "zod";
+
+export const editTradePost = async (formData: FormData) => {
+    const profileId = formData.get('profileId');
+    const userId = formData.get('userId');
+    const content = formData.get('content');
+
+    await db.tradePost.update({
+        where: id,
+        data: {
+            profileId: profileId as string,
+            userId: userId as string,
+            title: title as string,
+            image: image as string,
+            description: description as string,
+        }
+    });
+
+    revalidatePath(`/profile/${profileId}`); // profile check for data change and reloads
+
+    return {
+        success: true,
+    };
+};

--- a/src/actions/trade-posts/edit-trade-post.ts
+++ b/src/actions/trade-posts/edit-trade-post.ts
@@ -11,7 +11,6 @@ export const editTradePost = async (formData: FormData) => {
     const content = formData.get('content');
 
     await db.tradePost.update({
-        where: id,
         data: {
             profileId: profileId as string,
             userId: userId as string,

--- a/src/app/(protected)/profile/[id]/page.tsx
+++ b/src/app/(protected)/profile/[id]/page.tsx
@@ -28,16 +28,14 @@ async function getTradePosts(profileId: string){
 		where: {
 			profileId: profileId,
 		},
-		select: {
-			title: true,
-			image: true,
-			description: true,
-			price: true,
-			postType: true,
-		},
 	});
 
-	return tradePosts;
+	const modifiedTradePosts = tradePosts.map((tradePost) => ({
+		...tradePost,
+		user: undefined,
+	}));
+
+	return modifiedTradePosts;
 }
 const Profile = async ({ params }: any) => {
 	// Profile page for example is a server component
@@ -56,7 +54,7 @@ const Profile = async ({ params }: any) => {
 				<ProfileCard profile={profile}></ProfileCard>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
-				<Showcase params={ params } tradePosts={ tradePosts }></Showcase>
+				<Showcase params={ params } tradePosts={tradePosts}></Showcase>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
 				{/*<Feeds params={params} comments={comments}></Feeds>*/}

--- a/src/app/(protected)/profile/[id]/page.tsx
+++ b/src/app/(protected)/profile/[id]/page.tsx
@@ -20,14 +20,7 @@ async function getComments(profileId: string) {
 		},
 	});
 
-	const modifiedComments = comments.map((comment) => ({
-		...comment,
-		name: comment.user?.name,
-		image: comment.user?.image,
-		user: undefined,
-	}));
-
-	return modifiedComments;
+	return comments;
 }
 const Profile = async ({ params }: any) => {
 	// Profile page for example is a server component

--- a/src/app/(protected)/profile/[id]/page.tsx
+++ b/src/app/(protected)/profile/[id]/page.tsx
@@ -23,21 +23,17 @@ async function getComments(profileId: string) {
 	return comments;
 }
 
-async function getTradePosts(profileID: string){
+async function getTradePosts(profileId: string){
 	const tradePosts = await db.tradePost.findMany({
 		where: {
-			profileID: profileID,
+			profileId: profileId,
 		},
-		include: {
-			user: {
-				select: {
-					title: true,
-					image: true,
-					description: true,
-					price: true,
-					postType: true,
-				},
-			},
+		select: {
+			title: true,
+			image: true,
+			description: true,
+			price: true,
+			postType: true,
 		},
 	});
 
@@ -60,7 +56,7 @@ const Profile = async ({ params }: any) => {
 				<ProfileCard profile={profile}></ProfileCard>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
-				<Showcase></Showcase>
+				<Showcase params={ params } tradePosts={ tradePosts }></Showcase>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
 				{/*<Feeds params={params} comments={comments}></Feeds>*/}

--- a/src/app/(protected)/profile/[id]/page.tsx
+++ b/src/app/(protected)/profile/[id]/page.tsx
@@ -22,6 +22,27 @@ async function getComments(profileId: string) {
 
 	return comments;
 }
+
+async function getTradePosts(profileID: string){
+	const tradePosts = await db.tradePost.findMany({
+		where: {
+			profileID: profileID,
+		},
+		include: {
+			user: {
+				select: {
+					title: true,
+					image: true,
+					description: true,
+					price: true,
+					postType: true,
+				},
+			},
+		},
+	});
+
+	return tradePosts;
+}
 const Profile = async ({ params }: any) => {
 	// Profile page for example is a server component
 	const profile = await getUserById(params.id);
@@ -30,6 +51,8 @@ const Profile = async ({ params }: any) => {
 	}
 
 	const comments = await getComments(params.id);
+
+	const tradePosts = await getTradePosts(params.id);
 
 	return (
 		<div className='w-full h-full grid grid-cols-3 grid-rows-2'>
@@ -40,7 +63,7 @@ const Profile = async ({ params }: any) => {
 				<Showcase></Showcase>
 			</div>
 			<div className='col-span-2 row-span-1 p-4'>
-				<Feeds params={params} comments={comments}></Feeds>
+				{/*<Feeds params={params} comments={comments}></Feeds>*/}
 			</div>
 		</div>
 	);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,17 +33,18 @@ export const {
 			}
 			if (token.role && session.user) {
 				session.user.role = token.role as UserRole;
-				session.user.username = token.username;
 			}
 			return session;
 		},
-		async jwt({ token }) {
+		async jwt({ token, user }) {
+			if (user) {
+				token.sub = user.id;
+			}
 			if (!token.sub) return token;
 			const existingUser = await getUserById(token.sub);
 			if (!existingUser) return token;
 
 			token.role = existingUser.role;
-			token.username = existingUser.username;
 			return token;
 		},
 	},

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -47,13 +47,13 @@ const SignUpForm = () => {
 						<label className='relative input input-bordered flex items-center gap-2'>
 							<FaUser />
 							<input
-								{...register('username')}
+								{...register('name')}
 								type='username'
 								placeholder='Username'
 								className='px-4 py-2 rounded'
 							/>
-							{errors.username && (
-								<p className='absolute right-4 text-red-500 text-xs font-semibold'>{`${errors.username.message}`}</p>
+							{errors.name && (
+								<p className='absolute right-4 text-red-500 text-xs font-semibold'>{`${errors.name.message}`}</p>
 							)}
 						</label>
 

--- a/src/components/profile/Feeds.tsx
+++ b/src/components/profile/Feeds.tsx
@@ -64,6 +64,7 @@ const Feeds = ({ params, comments }: any) => {
 				{activeTab === 'comments' && <Comments params={params} comments={comments}></Comments>}
 				{activeTab === 'follows' && <Follows></Follows>}
 				{activeTab === 'contacts' && <Contacts></Contacts>}
+
 			</div>
 		</div>
 	);

--- a/src/components/profile/Showcase.tsx
+++ b/src/components/profile/Showcase.tsx
@@ -8,7 +8,7 @@ import { FaHandshake } from 'react-icons/fa';
 
 import { FaSignsPost } from 'react-icons/fa6';
 
-const Showcase = () => {
+const Showcase = ({ params, tradePosts }: any) => {
 	const [activeTab, setActiveTab] = useState('moodboard');
 
 	const handleTabClick = (tab: React.SetStateAction<string>) => {
@@ -49,7 +49,7 @@ const Showcase = () => {
 			<div className='w-[69rem] h-[23rem] p-4'>
 				{activeTab === 'moodboard' && <Moodboard></Moodboard>}
 				{activeTab === 'affiliation' && <Affiliation></Affiliation>}
-				{activeTab === 'posts' && <Posts></Posts>}
+				{activeTab === 'posts' && <Posts params={params} tradePosts={tradePosts}></Posts>}
 			</div>
 		</div>
 	);

--- a/src/components/profile/ui/Feeds/Comments.tsx
+++ b/src/components/profile/ui/Feeds/Comments.tsx
@@ -48,7 +48,7 @@ const Comments = ({ params, comments }: any) => {
 								<div className='avatar'>
 									<div className='rounded-full w-14 ring ring-black ring-offset-black ring-offset-1'>
 										<Image
-											src={comment.image}
+											src={comment.user.image}
 											height={48}
 											width={48}
 											alt='avatar'
@@ -57,7 +57,7 @@ const Comments = ({ params, comments }: any) => {
 									</div>
 								</div>
 								<div className='flex flex-col pl-4'>
-									<h1 className='text-lg font-semibold'>{comment.name}</h1>
+									<h1 className='text-lg font-semibold'>{comment.user.name}</h1>
 									<p className='text-sm text-gray-500'>
 										{new Date(comment.createdAt).toLocaleDateString()}
 									</p>

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -1,7 +1,7 @@
 'use client';
 // import { PostsConfig } from '@/config/site-config';
 // import Image from 'next/image';
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
 import {useSession} from "next-auth/react";
 import {MdAddBox, MdEditSquare} from "react-icons/md";
@@ -15,7 +15,14 @@ const Posts = ({ params, tradePosts }: any) => {
 	const session = useSession();
 	const [selectedTradePost, setSelectedTradePost] = useState<TTradePost | null>(null);
 
-	const handleEditClick = (tradePost: TTradePost) => {
+	const handleAddTradePost = () => {
+		const form = document.getElementById('addTradePost_form') as HTMLFormElement
+		const modal = document.getElementById('addTradePost_modal') as HTMLDialogElement
+		form.reset();
+		modal.showModal();
+	}
+
+	const handleEditTradePost = (tradePost: TTradePost) => {
 		setSelectedTradePost(tradePost);
 		(document.getElementById('editTradePost_modal') as HTMLDialogElement).showModal();
 	};
@@ -23,7 +30,7 @@ const Posts = ({ params, tradePosts }: any) => {
 	return (
 		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
-				{tradePosts.length === 0 ?(
+				{tradePosts.length === 0 ? (
 					<div className='w-full h-full flex justify-center items-center'>
 						<h1 className='text-xl'>No Trade Posts</h1>
 					</div>
@@ -41,7 +48,7 @@ const Posts = ({ params, tradePosts }: any) => {
 								</p>
 								{tradePosts.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
 									<button className='btn rounded-xl absolute -top-2 -right-2'
-											onClick={() => handleEditClick(tradePost)}>
+											onClick={() => handleEditTradePost(tradePost)}>
 										<MdEditSquare/>
 									</button>
 								) : null}
@@ -50,140 +57,151 @@ const Posts = ({ params, tradePosts }: any) => {
 					))
 				)}
 				{tradePosts.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
-					<div className="flex justify-center items-center bg-stone-950 col-span-1 m-4 rounded-xl relative overflow-hidden">
+					<div
+						className="flex justify-center items-center bg-stone-950 col-span-1 m-4 rounded-xl relative overflow-hidden">
 						<button className="btn rounded-xl"
-								onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
+								onClick={handleAddTradePost}>
 							<MdAddBox/> Create new post
 						</button>
 					</div>
 				) : null}
 			</div>
-			<dialog id='addTradePost_modal' className='modal'>
-				<div className='modal-box rounded-xl'>
-					<form action={addTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
-						<label className='form-control size-full gap-4'>
-							Add a new post:
-							<input type='hidden' name='profileId' value={params.id}/>
-							<input type='hidden' name='userId' value={session.data?.user.id!}/>
-							<label className="input input-bordered flex items-center gap-2 rounded-xl">
-								Title:
-								<input type="text" name='title' className="grow" placeholder="Enter Title..."/>
-							</label>
-							<label className="input input-bordered flex items-center gap-2 rounded-xl">
-								Image:
-								<input type="text" name='image' className="grow" placeholder="Enter Image URL..."/>
-							</label>
-							<label>
-								Description
-								<textarea
-									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
-									name='description'
-									placeholder='Enter Description...'></textarea>
-							</label>
-							<label className="input input-bordered flex items-center gap-2 rounded-xl">
-								Price:
-								<input type="text" name='price' className="grow" placeholder="Enter Price..."/>
-							</label>
-							<div className='flex flex-row items-center justify-evenly'>
-								<div className="form-control">
-									<label className="label cursor-pointer gap-4">
-										<span className="label-text">Selling</span>
-										<input type="radio" name="postType" defaultValue="Selling"
-											   className="radio checked:bg-green-500"
-											   checked/>
-									</label>
+
+			{tradePosts.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
+				<dialog id='addTradePost_modal' className='modal'>
+					<div className='modal-box rounded-xl'>
+						<form id='addTradePost_form' action={addTradePost}
+							  className='px-2 flex flex-col gap-4 items-end size-full'>
+							<label className='form-control size-full gap-4'>
+								Add a new post:
+								<input type='hidden' name='profileId' value={params.id}/>
+								<input type='hidden' name='userId' value={session.data?.user.id!}/>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Title:
+									<input type="text" name='title' className="grow" placeholder="Enter Title..."/>
+								</label>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Image:
+									<input type="text" name='image' className="grow"
+										   placeholder="Enter Image URL..."/>
+								</label>
+								<label>
+									Description
+									<textarea
+										className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
+										name='description'
+										placeholder='Enter Description...'></textarea>
+								</label>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Price:
+									<input type="text" name='price' className="grow" placeholder="Enter Price..."/>
+								</label>
+								<div className='flex flex-row items-center justify-evenly'>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Selling</span>
+											<input type="radio" name="postType" defaultValue="Selling"
+												   className="radio checked:bg-green-500"
+												   checked/>
+										</label>
+									</div>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Buying</span>
+											<input type="radio" name="postType" defaultValue="Buying"
+												   className="radio checked:bg-red-500"
+												   checked/>
+										</label>
+									</div>
 								</div>
-								<div className="form-control">
-									<label className="label cursor-pointer gap-4">
-										<span className="label-text">Buying</span>
-										<input type="radio" name="postType" defaultValue="Buying"
-											   className="radio checked:bg-red-500"
-											   checked/>
-									</label>
-								</div>
-							</div>
-						</label>
-						<button
-							className='btn btn-outline rounded-xl btn-sm'
-							type='submit'
-							onClick={() => {
-								(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
-							}}>
-							Submit
-						</button>
-					</form>
-				</div>
-				<form method='dialog' className='modal-backdrop'>
-					<button>close</button>
-				</form>
-			</dialog>
-			<dialog id='editTradePost_modal' className='modal'>
-				<div className='modal-box rounded-xl'>
-					<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
-						<label className='form-control size-full gap-4'>
-							Edit this post:
-							<input type='hidden' name='id' value={selectedTradePost?.id}/>
-							<input type='hidden' name='profileId' value={params.id}/>
-							<input type='hidden' name='userId' value={session.data?.user.id!}/>
-							<label className="input input-bordered flex items-center gap-2 rounded-xl">
-								Title:
-								<input type="text" name='title' className="grow" defaultValue={selectedTradePost?.title}/>
 							</label>
-							<label className="input input-bordered flex items-center gap-2 rounded-xl">
-								Image:
-								<input type="text" name='image' className="grow" defaultValue={selectedTradePost?.image}/>
-							</label>
-							<textarea
-								className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
-								name='description'
-								defaultValue={selectedTradePost?.description}></textarea>
-							<label className="input input-bordered flex items-center gap-2 rounded-xl">
-								Price:
-								<input type="text" name='price' className="grow" defaultValue={selectedTradePost?.price}/>
-							</label>
-							<div className='flex flex-row items-center justify-evenly'>
-								<div className="form-control">
-									<label className="label cursor-pointer gap-4">
-										<span className="label-text">Selling</span>
-										<input type="radio" name="postType" defaultValue="Selling"
-											   className="radio"
-											   checked/>
-									</label>
-								</div>
-								<div className="form-control">
-									<label className="label cursor-pointer gap-4">
-										<span className="label-text">Buying</span>
-										<input type="radio" name="postType" defaultValue="Buying"
-											   className="radio"/>
-									</label>
-								</div>
-							</div>
-						</label>
-						<div className='flex flex-row w-full justify-between items-center'>
-							<button
-								className='btn btn-outline btn-error rounded-xl btn-sm'
-								formAction={deleteTradePost}
-								type='submit'
-								onClick={() => {
-									(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
-								}}>
-								Delete
-							</button>
 							<button
 								className='btn btn-outline rounded-xl btn-sm'
 								type='submit'
-								onClick={() => {
-									(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
-								}}>
+								onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).close()}>
 								Submit
 							</button>
-						</div>
+						</form>
+					</div>
+					<form method='dialog' className='modal-backdrop'>
+						<button>close</button>
 					</form>
-				</div>
-				<form method='dialog' className='modal-backdrop'>
-					<button>close</button>
-				</form>
-			</dialog>
+				</dialog>
+			) : null}
+
+			{tradePosts.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
+				<dialog id='editTradePost_modal' className='modal'>
+					<div className='modal-box rounded-xl'>
+						<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
+							<label className='form-control size-full gap-4'>
+								Edit this post:
+								<input type='hidden' name='id' value={selectedTradePost?.id}/>
+								<input type='hidden' name='profileId' value={params.id}/>
+								<input type='hidden' name='userId' value={session.data?.user.id!}/>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Title:
+									<input type="text" name='title' className="grow"
+										   defaultValue={selectedTradePost?.title}/>
+								</label>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Image:
+									<input type="text" name='image' className="grow"
+										   defaultValue={selectedTradePost?.image}/>
+								</label>
+								<textarea
+									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
+									name='description'
+									defaultValue={selectedTradePost?.description}></textarea>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Price:
+									<input type="text" name='price' className="grow"
+										   defaultValue={selectedTradePost?.price}/>
+								</label>
+								<div className='flex flex-row items-center justify-evenly'>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Selling</span>
+											<input type="radio" name="postType" defaultValue="Selling"
+												   className="radio"
+												   checked/>
+										</label>
+									</div>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Buying</span>
+											<input type="radio" name="postType" defaultValue="Buying"
+												   className="radio"
+												   checked/>
+										</label>
+									</div>
+								</div>
+							</label>
+							<div className='flex flex-row w-full justify-between items-center'>
+								<button
+									className='btn btn-outline btn-error rounded-xl btn-sm'
+									formAction={deleteTradePost}
+									type='submit'
+									onClick={() => {
+										(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
+									}}>
+									Delete
+								</button>
+								<button
+									className='btn btn-outline rounded-xl btn-sm'
+									type='submit'
+									onClick={() => {
+										(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
+									}}>
+									Submit
+								</button>
+							</div>
+						</form>
+					</div>
+					<form method='dialog' className='modal-backdrop'>
+						<button>close</button>
+					</form>
+				</dialog>
+			) : null}
 		</div>
 	);
 };

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -8,16 +8,13 @@ import {useSession} from "next-auth/react";
 import {MdAddBox, MdEditSquare} from "react-icons/md";
 import {TTradePost} from "@/types/types";
 import {addTradePost} from "@/actions/trade-posts/add-trade-post";
+import {editTradePost} from "@/actions/trade-posts/edit-trade-post";
 
 
 const Posts = ({ params, tradePosts }: any) => {
 	const session = useSession();
 	return (
 		<div className='w-full h-full overflow-auto'>
-			<button className="btn rounded-xl"
-					onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
-				<MdAddBox />
-			</button>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
 				{tradePosts.map((tradePost: TTradePost) => {
 					return (
@@ -33,12 +30,18 @@ const Posts = ({ params, tradePosts }: any) => {
 								</p>
 								<button className='btn rounded-xl absolute -top-2 -right-2'
 										onClick={() => (document.getElementById('editTradePost_modal') as HTMLDialogElement).showModal()}>
-									<MdEditSquare />
+									<MdEditSquare/>
 								</button>
 							</DirectionAwareHover>
 						</div>
 					);
 				})}
+				<div className="flex justify-center items-center bg-stone-950 col-span-1 m-4 rounded-xl relative overflow-hidden">
+					<button className="btn rounded-xl"
+							onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
+						<MdAddBox/> Create new post
+					</button>
+				</div>
 			</div>
 			<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>
 				<dialog id='addTradePost_modal' className='modal'>
@@ -64,27 +67,24 @@ const Posts = ({ params, tradePosts }: any) => {
 									Price:
 									<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>
 								</label>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Post Type:
-									<input type="text" name='postType' className="grow" placeholder="type"/>
-								</label>
-								{/*<div className='flex flex-row items-center justify-evenly'>*/}
-								{/*	<div className="form-control">*/}
-								{/*		<label className="label cursor-pointer gap-4">*/}
-								{/*			<span className="label-text">Selling</span>*/}
-								{/*			<input type="radio" name="radio-10"*/}
-								{/*				   className="radio checked:bg-green-500"*/}
-								{/*				   checked/>*/}
-								{/*		</label>*/}
-								{/*	</div>*/}
-								{/*	<div className="form-control">*/}
-								{/*		<label className="label cursor-pointer gap-4">*/}
-								{/*			<span className="label-text">Buying</span>*/}
-								{/*			<input type="radio" name="radio-10" className="radio checked:bg-red-500"*/}
-								{/*				   checked/>*/}
-								{/*		</label>*/}
-								{/*	</div>*/}
-								{/*</div>*/}
+								<div className='flex flex-row items-center justify-evenly'>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Selling</span>
+											<input type="radio" name="postType" defaultValue="Selling"
+												   className="radio checked:bg-green-500"
+												   checked/>
+										</label>
+									</div>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Buying</span>
+											<input type="radio" name="postType" defaultValue="Buying"
+												   className="radio checked:bg-red-500"
+												   checked/>
+										</label>
+									</div>
+								</div>
 							</label>
 							<button
 								className='btn btn-outline rounded-xl btn-sm'
@@ -102,70 +102,65 @@ const Posts = ({ params, tradePosts }: any) => {
 					</form>
 				</dialog>
 			</div>
-			{/*<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>*/}
-			{/*	<dialog id='editTradePost_modal' className='modal'>*/}
-			{/*		<div className='modal-box rounded-xl'>*/}
-			{/*			<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>*/}
-			{/*				<label className='form-control size-full gap-4'>*/}
-			{/*					Edit this post:*/}
-			{/*					<input type='hidden' name='profileId' value={params.id}/>*/}
-			{/*					<input type='hidden' name='userId' value={session.data?.user.id!}/>*/}
-			{/*					<label className="input input-bordered flex items-center gap-2 rounded-xl">*/}
-			{/*						Title:*/}
-			{/*						<input type="text" name='title' className="grow" placeholder="Daisy"/>*/}
-			{/*					</label>*/}
-			{/*					<label className="input input-bordered flex items-center gap-2 rounded-xl">*/}
-			{/*						Image:*/}
-			{/*						<input type="text" name='image' className="grow" placeholder="daisy@site.com"/>*/}
-			{/*					</label>*/}
-			{/*					<textarea*/}
-			{/*						className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'*/}
-			{/*						name='description'*/}
-			{/*						placeholder='Provide a discription for your post...'></textarea>*/}
-			{/*					<label className="input input-bordered flex items-center gap-2 rounded-xl">*/}
-			{/*						Price:*/}
-			{/*						<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>*/}
-			{/*					</label>*/}
-			{/*					<div className='flex flex-row items-center justify-evenly'>*/}
-			{/*						<div className="form-control">*/}
-			{/*							<label className="label cursor-pointer gap-4">*/}
-			{/*								<span className="label-text">Selling</span>*/}
-			{/*								<input type="radio" name="radio-10"*/}
-			{/*									   className="radio checked:bg-green-500"*/}
-			{/*									   checked/>*/}
-			{/*							</label>*/}
-			{/*						</div>*/}
-			{/*						<div className="form-control">*/}
-			{/*							<label className="label cursor-pointer gap-4">*/}
-			{/*								<span className="label-text">Buying</span>*/}
-			{/*								<input type="radio" name="radio-10" className="radio checked:bg-red-500"*/}
-			{/*									   checked/>*/}
-			{/*							</label>*/}
-			{/*						</div>*/}
-			{/*					</div>*/}
-			{/*				</label>*/}
-			{/*				<button*/}
-			{/*					className='btn btn-outline rounded-xl btn-sm'*/}
-			{/*					type='submit'*/}
-			{/*					onClick={() => {*/}
-			{/*						(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();*/}
-			{/*						// mutate(url);*/}
-			{/*					}}>*/}
-			{/*					Submit*/}
-			{/*				</button>*/}
-			{/*			</form>*/}
-			{/*		</div>*/}
-			{/*		<form method='dialog' className='modal-backdrop'>*/}
-			{/*			<button>close</button>*/}
-			{/*		</form>*/}
-			{/*	</dialog>*/}
-			{/*	<div className='join'>*/}
-			{/*		<button className='join-item btn btn-sm btn-active'>1</button>*/}
-			{/*		<button className='join-item btn btn-sm'>2</button>*/}
-			{/*		<button className='join-item btn btn-sm'>3</button>*/}
-			{/*		<button className='join-item btn btn-sm'>4</button>*/}
-			{/*	</div>*/}
-			{/*</div>*/}
+			<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>
+				<dialog id='editTradePost_modal' className='modal'>
+					<div className='modal-box rounded-xl'>
+						<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
+							<label className='form-control size-full gap-4'>
+								Edit this post:
+								<input type='hidden' name='profileId' value={params.id}/>
+								<input type='hidden' name='userId' value={session.data?.user.id!}/>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Title:
+									<input type="text" name='title' className="grow" placeholder="Daisy"/>
+								</label>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Image:
+									<input type="text" name='image' className="grow" placeholder="daisy@site.com"/>
+								</label>
+								<textarea
+									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
+									name='description'
+									placeholder='Provide a discription for your post...'></textarea>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Price:
+									<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>
+								</label>
+								<div className='flex flex-row items-center justify-evenly'>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Selling</span>
+											<input type="radio" name="postType" defaultValue="Selling"
+												   className="radio checked:bg-green-500"
+												   checked/>
+										</label>
+									</div>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Buying</span>
+											<input type="radio" name="postType" defaultValue="Buying"
+												   className="radio checked:bg-red-500"
+												   checked/>
+										</label>
+									</div>
+								</div>
+							</label>
+							<button
+								className='btn btn-outline rounded-xl btn-sm'
+								type='submit'
+								onClick={() => {
+									(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
+									// mutate(url);
+								}}>
+								Submit
+							</button>
+						</form>
+					</div>
+					<form method='dialog' className='modal-backdrop'>
+						<button>close</button>
+					</form>
+				</dialog>
+			</div>
 		</div>
 );
 };

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -2,7 +2,7 @@
 import
 { PostsConfig } from '@/config/site-config';
 import Image from 'next/image';
-import React from 'react';
+import React, {useState} from 'react';
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
 import {useSession} from "next-auth/react";
 import {MdAddBox, MdEditSquare} from "react-icons/md";
@@ -13,6 +13,13 @@ import {editTradePost} from "@/actions/trade-posts/edit-trade-post";
 
 const Posts = ({ params, tradePosts }: any) => {
 	const session = useSession();
+	const [selectedTradePost, setSelectedTradePost] = useState<TTradePost | null>(null);
+
+	const handleEditClick = (tradePost: TTradePost) => {
+		setSelectedTradePost(tradePost);
+		(document.getElementById('editTradePost_modal') as HTMLDialogElement).showModal();
+	};
+
 	return (
 		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
@@ -29,7 +36,7 @@ const Posts = ({ params, tradePosts }: any) => {
 									{tradePost.price} / {tradePost.description}
 								</p>
 								<button className='btn rounded-xl absolute -top-2 -right-2'
-										onClick={() => (document.getElementById('editTradePost_modal') as HTMLDialogElement).showModal()}>
+										onClick={() => handleEditClick(tradePost)}>
 									<MdEditSquare/>
 								</button>
 							</DirectionAwareHover>
@@ -108,23 +115,24 @@ const Posts = ({ params, tradePosts }: any) => {
 						<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
 							<label className='form-control size-full gap-4'>
 								Edit this post:
+								<input type='hidden' name='id' value={selectedTradePost?.id}/>
 								<input type='hidden' name='profileId' value={params.id}/>
 								<input type='hidden' name='userId' value={session.data?.user.id!}/>
 								<label className="input input-bordered flex items-center gap-2 rounded-xl">
 									Title:
-									<input type="text" name='title' className="grow" placeholder="Daisy"/>
+									<input type="text" name='title' className="grow" defaultValue={selectedTradePost?.title}/>
 								</label>
 								<label className="input input-bordered flex items-center gap-2 rounded-xl">
 									Image:
-									<input type="text" name='image' className="grow" placeholder="daisy@site.com"/>
+									<input type="text" name='image' className="grow" defaultValue={selectedTradePost?.image}/>
 								</label>
 								<textarea
 									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
 									name='description'
-									placeholder='Provide a discription for your post...'></textarea>
+									defaultValue={selectedTradePost?.description}></textarea>
 								<label className="input input-bordered flex items-center gap-2 rounded-xl">
 									Price:
-									<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>
+									<input type="text" name='price' className="grow" defaultValue={selectedTradePost?.price}/>
 								</label>
 								<div className='flex flex-row items-center justify-evenly'>
 									<div className="form-control">
@@ -149,7 +157,7 @@ const Posts = ({ params, tradePosts }: any) => {
 								className='btn btn-outline rounded-xl btn-sm'
 								type='submit'
 								onClick={() => {
-									(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
+									(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
 									// mutate(url);
 								}}>
 								Submit

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -50,127 +50,126 @@ const Posts = ({ params, tradePosts }: any) => {
 					</button>
 				</div>
 			</div>
-			<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>
-				<dialog id='addTradePost_modal' className='modal'>
-					<div className='modal-box rounded-xl'>
-						<form action={addTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
-							<label className='form-control size-full gap-4'>
-								Add a new post:
-								<input type='hidden' name='profileId' value={params.id}/>
-								<input type='hidden' name='userId' value={session.data?.user.id!}/>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Title:
-									<input type="text" name='title' className="grow" placeholder="Daisy"/>
-								</label>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Image:
-									<input type="text" name='image' className="grow" placeholder="Url..."/>
-								</label>
+			<dialog id='addTradePost_modal' className='modal'>
+				<div className='modal-box rounded-xl'>
+					<form action={addTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
+						<label className='form-control size-full gap-4'>
+							Add a new post:
+							<input type='hidden' name='profileId' value={params.id}/>
+							<input type='hidden' name='userId' value={session.data?.user.id!}/>
+							<label className="input input-bordered flex items-center gap-2 rounded-xl">
+								Title:
+								<input type="text" name='title' className="grow" placeholder="Enter Title..."/>
+							</label>
+							<label className="input input-bordered flex items-center gap-2 rounded-xl">
+								Image:
+								<input type="text" name='image' className="grow" placeholder="Enter Image URL..."/>
+							</label>
+							<label>
+								Description
 								<textarea
 									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
 									name='description'
-									placeholder='Provide a discription for your post...'></textarea>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Price:
-									<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>
-								</label>
-								<div className='flex flex-row items-center justify-evenly'>
-									<div className="form-control">
-										<label className="label cursor-pointer gap-4">
-											<span className="label-text">Selling</span>
-											<input type="radio" name="postType" defaultValue="Selling"
-												   className="radio checked:bg-green-500"
-												   checked/>
-										</label>
-									</div>
-									<div className="form-control">
-										<label className="label cursor-pointer gap-4">
-											<span className="label-text">Buying</span>
-											<input type="radio" name="postType" defaultValue="Buying"
-												   className="radio checked:bg-red-500"
-												   checked/>
-										</label>
-									</div>
-								</div>
+									placeholder='Enter Description...'></textarea>
 							</label>
-							<button
-								className='btn btn-outline rounded-xl btn-sm'
-								type='submit'
-								onClick={() => {
-									(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
-									// mutate(url);
-								}}>
-								Submit
-							</button>
-						</form>
-					</div>
-					<form method='dialog' className='modal-backdrop'>
-						<button>close</button>
-					</form>
-				</dialog>
-			</div>
-			<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>
-				<dialog id='editTradePost_modal' className='modal'>
-					<div className='modal-box rounded-xl'>
-						<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
-							<label className='form-control size-full gap-4'>
-								Edit this post:
-								<input type='hidden' name='id' value={selectedTradePost?.id}/>
-								<input type='hidden' name='profileId' value={params.id}/>
-								<input type='hidden' name='userId' value={session.data?.user.id!}/>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Title:
-									<input type="text" name='title' className="grow" defaultValue={selectedTradePost?.title}/>
-								</label>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Image:
-									<input type="text" name='image' className="grow" defaultValue={selectedTradePost?.image}/>
-								</label>
-								<textarea
-									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
-									name='description'
-									defaultValue={selectedTradePost?.description}></textarea>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Price:
-									<input type="text" name='price' className="grow" defaultValue={selectedTradePost?.price}/>
-								</label>
-								<div className='flex flex-row items-center justify-evenly'>
-									<div className="form-control">
-										<label className="label cursor-pointer gap-4">
-											<span className="label-text">Selling</span>
-											<input type="radio" name="postType" defaultValue="Selling"
-												   className="radio checked:bg-green-500"
-												   checked/>
-										</label>
-									</div>
-									<div className="form-control">
-										<label className="label cursor-pointer gap-4">
-											<span className="label-text">Buying</span>
-											<input type="radio" name="postType" defaultValue="Buying"
-												   className="radio checked:bg-red-500"
-												   checked/>
-										</label>
-									</div>
-								</div>
+							<label className="input input-bordered flex items-center gap-2 rounded-xl">
+								Price:
+								<input type="text" name='price' className="grow" placeholder="Enter Price..."/>
 							</label>
-							<button
-								className='btn btn-outline rounded-xl btn-sm'
-								type='submit'
-								onClick={() => {
-									(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
-									// mutate(url);
-								}}>
-								Submit
-							</button>
-						</form>
-					</div>
-					<form method='dialog' className='modal-backdrop'>
-						<button>close</button>
+							<div className='flex flex-row items-center justify-evenly'>
+								<div className="form-control">
+									<label className="label cursor-pointer gap-4">
+										<span className="label-text">Selling</span>
+										<input type="radio" name="postType" defaultValue="Selling"
+											   className="radio checked:bg-green-500"
+											   checked/>
+									</label>
+								</div>
+								<div className="form-control">
+									<label className="label cursor-pointer gap-4">
+										<span className="label-text">Buying</span>
+										<input type="radio" name="postType" defaultValue="Buying"
+											   className="radio checked:bg-red-500"
+											   checked/>
+									</label>
+								</div>
+							</div>
+						</label>
+						<button
+							className='btn btn-outline rounded-xl btn-sm'
+							type='submit'
+							onClick={() => {
+								(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
+								// mutate(url);
+							}}>
+							Submit
+						</button>
 					</form>
-				</dialog>
-			</div>
+				</div>
+				<form method='dialog' className='modal-backdrop'>
+					<button>close</button>
+				</form>
+			</dialog>
+			<dialog id='editTradePost_modal' className='modal'>
+				<div className='modal-box rounded-xl'>
+					<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
+						<label className='form-control size-full gap-4'>
+							Edit this post:
+							<input type='hidden' name='id' value={selectedTradePost?.id}/>
+							<input type='hidden' name='profileId' value={params.id}/>
+							<input type='hidden' name='userId' value={session.data?.user.id!}/>
+							<label className="input input-bordered flex items-center gap-2 rounded-xl">
+								Title:
+								<input type="text" name='title' className="grow" defaultValue={selectedTradePost?.title}/>
+							</label>
+							<label className="input input-bordered flex items-center gap-2 rounded-xl">
+								Image:
+								<input type="text" name='image' className="grow" defaultValue={selectedTradePost?.image}/>
+							</label>
+							<textarea
+								className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
+								name='description'
+								defaultValue={selectedTradePost?.description}></textarea>
+							<label className="input input-bordered flex items-center gap-2 rounded-xl">
+								Price:
+								<input type="text" name='price' className="grow" defaultValue={selectedTradePost?.price}/>
+							</label>
+							<div className='flex flex-row items-center justify-evenly'>
+								<div className="form-control">
+									<label className="label cursor-pointer gap-4">
+										<span className="label-text">Selling</span>
+										<input type="radio" name="postType" defaultValue="Selling"
+											   className="radio checked:bg-green-500"
+											   checked/>
+									</label>
+								</div>
+								<div className="form-control">
+									<label className="label cursor-pointer gap-4">
+										<span className="label-text">Buying</span>
+										<input type="radio" name="postType" defaultValue="Buying"
+											   className="radio checked:bg-red-500"
+											   checked/>
+									</label>
+								</div>
+							</div>
+						</label>
+						<button
+							className='btn btn-outline rounded-xl btn-sm'
+							type='submit'
+							onClick={() => {
+								(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
+								// mutate(url);
+							}}>
+							Submit
+						</button>
+					</form>
+				</div>
+				<form method='dialog' className='modal-backdrop'>
+					<button>close</button>
+				</form>
+			</dialog>
 		</div>
-);
+	);
 };
 
 export default Posts;

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -21,6 +21,7 @@ const Posts = () => {
 								<p className='font-normal text-sm'>
 									{post.price} / {post.description}
 								</p>
+								<div className='absolute top-0 right-0'><a className='rounded-full p-2 bg-slate-500' href='#'>edit</a></div>
 							</DirectionAwareHover>
 						</div>
 					);

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -1,7 +1,7 @@
 'use client';
 // import { PostsConfig } from '@/config/site-config';
 // import Image from 'next/image';
-import React, {useCallback, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
 import {useSession} from "next-auth/react";
 import {MdAddBox, MdEditSquare} from "react-icons/md";
@@ -14,6 +14,13 @@ import {deleteTradePost} from "@/actions/trade-posts/delete-trade-post";
 const Posts = ({ params, tradePosts }: any) => {
 	const session = useSession();
 	const [selectedTradePost, setSelectedTradePost] = useState<TTradePost | null>(null);
+	const [postType, setPostType] = useState('');
+
+	useEffect(() => {
+		if (selectedTradePost?.postType) {
+			setPostType(selectedTradePost.postType);
+		}
+	}, [selectedTradePost]);
 
 	const handleAddTradePost = () => {
 		const form = document.getElementById('addTradePost_form') as HTMLFormElement
@@ -73,35 +80,48 @@ const Posts = ({ params, tradePosts }: any) => {
 						<form id='addTradePost_form' action={addTradePost}
 							  className='px-2 flex flex-col gap-4 items-end size-full'>
 							<label className='form-control size-full gap-4'>
-								Add a new post:
+								Create a new post:
 								<input type='hidden' name='profileId' value={params.id}/>
 								<input type='hidden' name='userId' value={session.data?.user.id!}/>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Title:
-									<input type="text" name='title' className="grow" placeholder="Enter Title..."/>
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Title</span>
+									</div>
+									<input type="text" name='title' placeholder="Enter title..."
+										   className="input input-bordered w-full rounded-xl"
+										   />
 								</label>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Image:
-									<input type="text" name='image' className="grow"
-										   placeholder="Enter Image URL..."/>
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Image</span>
+									</div>
+									<input type="text" name='image' placeholder="Enter url..."
+										   className="input input-bordered w-full rounded-xl"
+										   />
 								</label>
-								<label>
-									Description
-									<textarea
-										className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
-										name='description'
-										placeholder='Enter Description...'></textarea>
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Description</span>
+									</div>
+									<textarea name='description'
+											  className="textarea textarea-bordered text-base h-24 rounded-xl"
+											  placeholder="Enter description..."
+											  ></textarea>
 								</label>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Price:
-									<input type="text" name='price' className="grow" placeholder="Enter Price..."/>
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Price</span>
+									</div>
+									<input type="text" name='price' placeholder="Enter price..."
+										   className="input input-bordered w-full rounded-xl"
+										   />
 								</label>
-								<div className='flex flex-row items-center justify-evenly'>
+								<div className='flex flex-row items-center justify-evenly py-4'>
 									<div className="form-control">
 										<label className="label cursor-pointer gap-4">
 											<span className="label-text">Selling</span>
 											<input type="radio" name="postType" defaultValue="Selling"
-												   className="radio checked:bg-green-500"
+												   className="radio"
 												   checked/>
 										</label>
 									</div>
@@ -109,7 +129,7 @@ const Posts = ({ params, tradePosts }: any) => {
 										<label className="label cursor-pointer gap-4">
 											<span className="label-text">Buying</span>
 											<input type="radio" name="postType" defaultValue="Buying"
-												   className="radio checked:bg-red-500"
+												   className="radio"
 												   checked/>
 										</label>
 									</div>
@@ -138,32 +158,47 @@ const Posts = ({ params, tradePosts }: any) => {
 								<input type='hidden' name='id' value={selectedTradePost?.id}/>
 								<input type='hidden' name='profileId' value={params.id}/>
 								<input type='hidden' name='userId' value={session.data?.user.id!}/>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Title:
-									<input type="text" name='title' className="grow"
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Title</span>
+									</div>
+									<input type="text" name='title' placeholder="Enter title..."
+										   className="input input-bordered w-full rounded-xl"
 										   defaultValue={selectedTradePost?.title}/>
 								</label>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Image:
-									<input type="text" name='image' className="grow"
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Image</span>
+									</div>
+									<input type="text" name='image' placeholder="Enter url..."
+										   className="input input-bordered w-full rounded-xl"
 										   defaultValue={selectedTradePost?.image}/>
 								</label>
-								<textarea
-									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
-									name='description'
-									defaultValue={selectedTradePost?.description}></textarea>
-								<label className="input input-bordered flex items-center gap-2 rounded-xl">
-									Price:
-									<input type="text" name='price' className="grow"
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Description</span>
+									</div>
+									<textarea name='description'
+											  className="textarea textarea-bordered text-base h-24 rounded-xl"
+											  placeholder="Enter description..."
+											  defaultValue={selectedTradePost?.description}></textarea>
+								</label>
+								<label className="form-control w-full">
+									<div className="label">
+										<span className="label-text">Price</span>
+									</div>
+									<input type="text" name='price' placeholder="Enter price..."
+										   className="input input-bordered w-full rounded-xl"
 										   defaultValue={selectedTradePost?.price}/>
 								</label>
-								<div className='flex flex-row items-center justify-evenly'>
+								<div className='flex flex-row items-center justify-evenly py-4'>
 									<div className="form-control">
 										<label className="label cursor-pointer gap-4">
 											<span className="label-text">Selling</span>
 											<input type="radio" name="postType" defaultValue="Selling"
 												   className="radio"
-												   checked/>
+												   checked={postType === 'Selling'}
+												   onChange={() => setPostType('Selling')}/>
 										</label>
 									</div>
 									<div className="form-control">
@@ -171,7 +206,8 @@ const Posts = ({ params, tradePosts }: any) => {
 											<span className="label-text">Buying</span>
 											<input type="radio" name="postType" defaultValue="Buying"
 												   className="radio"
-												   checked/>
+												   checked={postType === 'Buying'}
+												   onChange={() => setPostType('Buying')}/>
 										</label>
 									</div>
 								</div>
@@ -184,7 +220,7 @@ const Posts = ({ params, tradePosts }: any) => {
 									onClick={() => {
 										(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
 									}}>
-									Delete
+								Delete
 								</button>
 								<button
 									className='btn btn-outline rounded-xl btn-sm'

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -1,7 +1,6 @@
 'use client';
-import
-{ PostsConfig } from '@/config/site-config';
-import Image from 'next/image';
+// import { PostsConfig } from '@/config/site-config';
+// import Image from 'next/image';
 import React, {useState} from 'react';
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
 import {useSession} from "next-auth/react";
@@ -40,21 +39,24 @@ const Posts = ({ params, tradePosts }: any) => {
 								<p className='font-normal text-sm'>
 									{tradePost.price} / {tradePost.description}
 								</p>
-								<button className='btn rounded-xl absolute -top-2 -right-2'
-										onClick={() => handleEditClick(tradePost)}>
-									<MdEditSquare/>
-								</button>
+								{tradePosts.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
+									<button className='btn rounded-xl absolute -top-2 -right-2'
+											onClick={() => handleEditClick(tradePost)}>
+										<MdEditSquare/>
+									</button>
+								) : null}
 							</DirectionAwareHover>
 						</div>
 					))
 				)}
-
-				<div className="flex justify-center items-center bg-stone-950 col-span-1 m-4 rounded-xl relative overflow-hidden">
-					<button className="btn rounded-xl"
-							onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
-						<MdAddBox/> Create new post
-					</button>
-				</div>
+				{tradePosts.length === 0 && params.id === session.data?.user.id || params.id === session.data?.user.id ? (
+					<div className="flex justify-center items-center bg-stone-950 col-span-1 m-4 rounded-xl relative overflow-hidden">
+						<button className="btn rounded-xl"
+								onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
+							<MdAddBox/> Create new post
+						</button>
+					</div>
+				) : null}
 			</div>
 			<dialog id='addTradePost_modal' className='modal'>
 				<div className='modal-box rounded-xl'>
@@ -144,7 +146,7 @@ const Posts = ({ params, tradePosts }: any) => {
 									<label className="label cursor-pointer gap-4">
 										<span className="label-text">Selling</span>
 										<input type="radio" name="postType" defaultValue="Selling"
-											   className="radio checked:bg-stone-400"
+											   className="radio"
 											   checked/>
 									</label>
 								</div>
@@ -152,8 +154,7 @@ const Posts = ({ params, tradePosts }: any) => {
 									<label className="label cursor-pointer gap-4">
 										<span className="label-text">Buying</span>
 										<input type="radio" name="postType" defaultValue="Buying"
-											   className="radio checked:bg-stone-400"
-											   checked/>
+											   className="radio"/>
 									</label>
 								</div>
 							</div>

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -1,11 +1,14 @@
 'use client';
-import { PostsConfig } from '@/config/site-config';
+import
+{ PostsConfig } from '@/config/site-config';
 import Image from 'next/image';
 import React from 'react';
-
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
+import {addTradePost} from "@/actions/trade-posts/add-trade-post";
+import {useSession} from "next-auth/react";
 
-const Posts = () => {
+const Posts = ({ params, tradePosts }: any) => {
+	const session = useSession();
 	return (
 		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
@@ -21,11 +24,66 @@ const Posts = () => {
 								<p className='font-normal text-sm'>
 									{post.price} / {post.description}
 								</p>
-								<div className='absolute top-0 right-0'><a className='rounded-full p-2 bg-slate-500' href='#'>edit</a></div>
+								<button
+									className='btn rounded-xl'
+									onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
+									edit
+								</button>
 							</DirectionAwareHover>
 						</div>
 					);
 				})}
+			</div>
+			<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>
+				<dialog id='addTradePost_modal' className='modal'>
+					<div className='modal-box rounded-xl'>
+						<form action={addTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
+							<label className='form-control size-full'>
+								<input type='hidden' name='profileId' value={params.id}/>
+								<input type='hidden' name='userId' value={session.data?.user.id!}/>
+								<input name='title' />
+								<input name='image' />
+								<textarea
+									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
+									name='description'
+									placeholder='Provide a discription for your post...'></textarea>
+								<input name='price' />
+								<div className="form-control">
+									<label className="label cursor-pointer">
+										<span className="label-text">Selling</span>
+										<input type="radio" name="radio-10" className="radio checked:bg-green-500"
+											   checked/>
+									</label>
+								</div>
+								<div className="form-control">
+									<label className="label cursor-pointer">
+										<span className="label-text">Buying</span>
+										<input type="radio" name="radio-10" className="radio checked:bg-red-500"
+											   checked/>
+									</label>
+								</div>
+							</label>
+							<button
+								className='btn btn-outline rounded-xl btn-sm'
+								type='submit'
+								onClick={() => {
+									(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
+									// mutate(url);
+								}}>
+								Submit
+							</button>
+						</form>
+					</div>
+					<form method='dialog' className='modal-backdrop'>
+						<button>close</button>
+					</form>
+				</dialog>
+				<div className='join'>
+					<button className='join-item btn btn-sm btn-active'>1</button>
+					<button className='join-item btn btn-sm'>2</button>
+					<button className='join-item btn btn-sm'>3</button>
+					<button className='join-item btn btn-sm'>4</button>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -4,9 +4,10 @@ import
 import Image from 'next/image';
 import React from 'react';
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
-import {addTradePost} from "@/actions/trade-posts/add-trade-post";
 import {useSession} from "next-auth/react";
-import { MdAddBox, MdEditSquare } from "react-icons/md";
+import {MdAddBox, MdEditSquare} from "react-icons/md";
+import {TTradePost} from "@/types/types";
+import {addTradePost} from "@/actions/trade-posts/add-trade-post";
 
 
 const Posts = ({ params, tradePosts }: any) => {
@@ -18,17 +19,17 @@ const Posts = ({ params, tradePosts }: any) => {
 				<MdAddBox />
 			</button>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
-				{PostsConfig.posts.map((post, index) => {
+				{tradePosts.map((tradePost: TTradePost) => {
 					return (
-						<div key={index} className='col-span-1 m-4 rounded-xl relative overflow-hidden'>
+						<div key={tradePost.id} className='col-span-1 m-4 rounded-xl relative overflow-hidden'>
 							{' '}
-							<DirectionAwareHover imageUrl={`${post.image}`}>
-								<p className='font-bold text-2xl'>{post.title}</p>
+							<DirectionAwareHover imageUrl={`${tradePost.image}`}>
+								<p className='font-bold text-2xl'>{tradePost.title}</p>
 								<p className='font-normal text-md'>
-									Status: <span className='text-bold'>{post.postType}</span>
+									Status: <span className='text-bold'>{tradePost.postType}</span>
 								</p>
 								<p className='font-normal text-sm'>
-									{post.price} / {post.description}
+									{tradePost.price} / {tradePost.description}
 								</p>
 								<button className='btn rounded-xl absolute -top-2 -right-2'
 										onClick={() => (document.getElementById('editTradePost_modal') as HTMLDialogElement).showModal()}>
@@ -53,7 +54,7 @@ const Posts = ({ params, tradePosts }: any) => {
 								</label>
 								<label className="input input-bordered flex items-center gap-2 rounded-xl">
 									Image:
-									<input type="text" name='image' className="grow" placeholder="daisy@site.com"/>
+									<input type="text" name='image' className="grow" placeholder="Url..."/>
 								</label>
 								<textarea
 									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
@@ -63,23 +64,27 @@ const Posts = ({ params, tradePosts }: any) => {
 									Price:
 									<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>
 								</label>
-								<div className='flex flex-row items-center justify-evenly'>
-									<div className="form-control">
-										<label className="label cursor-pointer gap-4">
-											<span className="label-text">Selling</span>
-											<input type="radio" name="radio-10"
-												   className="radio checked:bg-green-500"
-												   checked/>
-										</label>
-									</div>
-									<div className="form-control">
-										<label className="label cursor-pointer gap-4">
-											<span className="label-text">Buying</span>
-											<input type="radio" name="radio-10" className="radio checked:bg-red-500"
-												   checked/>
-										</label>
-									</div>
-								</div>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Post Type:
+									<input type="text" name='postType' className="grow" placeholder="type"/>
+								</label>
+								{/*<div className='flex flex-row items-center justify-evenly'>*/}
+								{/*	<div className="form-control">*/}
+								{/*		<label className="label cursor-pointer gap-4">*/}
+								{/*			<span className="label-text">Selling</span>*/}
+								{/*			<input type="radio" name="radio-10"*/}
+								{/*				   className="radio checked:bg-green-500"*/}
+								{/*				   checked/>*/}
+								{/*		</label>*/}
+								{/*	</div>*/}
+								{/*	<div className="form-control">*/}
+								{/*		<label className="label cursor-pointer gap-4">*/}
+								{/*			<span className="label-text">Buying</span>*/}
+								{/*			<input type="radio" name="radio-10" className="radio checked:bg-red-500"*/}
+								{/*				   checked/>*/}
+								{/*		</label>*/}
+								{/*	</div>*/}
+								{/*</div>*/}
 							</label>
 							<button
 								className='btn btn-outline rounded-xl btn-sm'

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -9,6 +9,7 @@ import {MdAddBox, MdEditSquare} from "react-icons/md";
 import {TTradePost} from "@/types/types";
 import {addTradePost} from "@/actions/trade-posts/add-trade-post";
 import {editTradePost} from "@/actions/trade-posts/edit-trade-post";
+import {deleteTradePost} from "@/actions/trade-posts/delete-trade-post";
 
 
 const Posts = ({ params, tradePosts }: any) => {
@@ -23,8 +24,12 @@ const Posts = ({ params, tradePosts }: any) => {
 	return (
 		<div className='w-full h-full overflow-auto'>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
-				{tradePosts.map((tradePost: TTradePost) => {
-					return (
+				{tradePosts.length === 0 ?(
+					<div className='w-full h-full flex justify-center items-center'>
+						<h1 className='text-xl'>No Trade Posts</h1>
+					</div>
+				) : (
+					tradePosts.map((tradePost: TTradePost) => (
 						<div key={tradePost.id} className='col-span-1 m-4 rounded-xl relative overflow-hidden'>
 							{' '}
 							<DirectionAwareHover imageUrl={`${tradePost.image}`}>
@@ -41,8 +46,9 @@ const Posts = ({ params, tradePosts }: any) => {
 								</button>
 							</DirectionAwareHover>
 						</div>
-					);
-				})}
+					))
+				)}
+
 				<div className="flex justify-center items-center bg-stone-950 col-span-1 m-4 rounded-xl relative overflow-hidden">
 					<button className="btn rounded-xl"
 							onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
@@ -100,7 +106,6 @@ const Posts = ({ params, tradePosts }: any) => {
 							type='submit'
 							onClick={() => {
 								(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();
-								// mutate(url);
 							}}>
 							Submit
 						</button>
@@ -139,7 +144,7 @@ const Posts = ({ params, tradePosts }: any) => {
 									<label className="label cursor-pointer gap-4">
 										<span className="label-text">Selling</span>
 										<input type="radio" name="postType" defaultValue="Selling"
-											   className="radio checked:bg-green-500"
+											   className="radio checked:bg-stone-400"
 											   checked/>
 									</label>
 								</div>
@@ -147,21 +152,31 @@ const Posts = ({ params, tradePosts }: any) => {
 									<label className="label cursor-pointer gap-4">
 										<span className="label-text">Buying</span>
 										<input type="radio" name="postType" defaultValue="Buying"
-											   className="radio checked:bg-red-500"
+											   className="radio checked:bg-stone-400"
 											   checked/>
 									</label>
 								</div>
 							</div>
 						</label>
-						<button
-							className='btn btn-outline rounded-xl btn-sm'
-							type='submit'
-							onClick={() => {
-								(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
-								// mutate(url);
-							}}>
-							Submit
-						</button>
+						<div className='flex flex-row w-full justify-between items-center'>
+							<button
+								className='btn btn-outline btn-error rounded-xl btn-sm'
+								formAction={deleteTradePost}
+								type='submit'
+								onClick={() => {
+									(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
+								}}>
+								Delete
+							</button>
+							<button
+								className='btn btn-outline rounded-xl btn-sm'
+								type='submit'
+								onClick={() => {
+									(document.getElementById('editTradePost_modal') as HTMLDialogElement).close();
+								}}>
+								Submit
+							</button>
+						</div>
 					</form>
 				</div>
 				<form method='dialog' className='modal-backdrop'>

--- a/src/components/profile/ui/Showcase/Posts.tsx
+++ b/src/components/profile/ui/Showcase/Posts.tsx
@@ -6,11 +6,17 @@ import React from 'react';
 import { DirectionAwareHover } from '@/components/ui/DirectionAwareHover';
 import {addTradePost} from "@/actions/trade-posts/add-trade-post";
 import {useSession} from "next-auth/react";
+import { MdAddBox, MdEditSquare } from "react-icons/md";
+
 
 const Posts = ({ params, tradePosts }: any) => {
 	const session = useSession();
 	return (
 		<div className='w-full h-full overflow-auto'>
+			<button className="btn rounded-xl"
+					onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
+				<MdAddBox />
+			</button>
 			<div className='w-full h-full grid grid-cols-2 auto-rows-[328px] overflow-auto'>
 				{PostsConfig.posts.map((post, index) => {
 					return (
@@ -24,10 +30,9 @@ const Posts = ({ params, tradePosts }: any) => {
 								<p className='font-normal text-sm'>
 									{post.price} / {post.description}
 								</p>
-								<button
-									className='btn rounded-xl'
-									onClick={() => (document.getElementById('addTradePost_modal') as HTMLDialogElement).showModal()}>
-									edit
+								<button className='btn rounded-xl absolute -top-2 -right-2'
+										onClick={() => (document.getElementById('editTradePost_modal') as HTMLDialogElement).showModal()}>
+									<MdEditSquare />
 								</button>
 							</DirectionAwareHover>
 						</div>
@@ -38,29 +43,42 @@ const Posts = ({ params, tradePosts }: any) => {
 				<dialog id='addTradePost_modal' className='modal'>
 					<div className='modal-box rounded-xl'>
 						<form action={addTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>
-							<label className='form-control size-full'>
+							<label className='form-control size-full gap-4'>
+								Add a new post:
 								<input type='hidden' name='profileId' value={params.id}/>
 								<input type='hidden' name='userId' value={session.data?.user.id!}/>
-								<input name='title' />
-								<input name='image' />
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Title:
+									<input type="text" name='title' className="grow" placeholder="Daisy"/>
+								</label>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Image:
+									<input type="text" name='image' className="grow" placeholder="daisy@site.com"/>
+								</label>
 								<textarea
 									className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'
 									name='description'
 									placeholder='Provide a discription for your post...'></textarea>
-								<input name='price' />
-								<div className="form-control">
-									<label className="label cursor-pointer">
-										<span className="label-text">Selling</span>
-										<input type="radio" name="radio-10" className="radio checked:bg-green-500"
-											   checked/>
-									</label>
-								</div>
-								<div className="form-control">
-									<label className="label cursor-pointer">
-										<span className="label-text">Buying</span>
-										<input type="radio" name="radio-10" className="radio checked:bg-red-500"
-											   checked/>
-									</label>
+								<label className="input input-bordered flex items-center gap-2 rounded-xl">
+									Price:
+									<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>
+								</label>
+								<div className='flex flex-row items-center justify-evenly'>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Selling</span>
+											<input type="radio" name="radio-10"
+												   className="radio checked:bg-green-500"
+												   checked/>
+										</label>
+									</div>
+									<div className="form-control">
+										<label className="label cursor-pointer gap-4">
+											<span className="label-text">Buying</span>
+											<input type="radio" name="radio-10" className="radio checked:bg-red-500"
+												   checked/>
+										</label>
+									</div>
 								</div>
 							</label>
 							<button
@@ -78,15 +96,73 @@ const Posts = ({ params, tradePosts }: any) => {
 						<button>close</button>
 					</form>
 				</dialog>
-				<div className='join'>
-					<button className='join-item btn btn-sm btn-active'>1</button>
-					<button className='join-item btn btn-sm'>2</button>
-					<button className='join-item btn btn-sm'>3</button>
-					<button className='join-item btn btn-sm'>4</button>
-				</div>
 			</div>
+			{/*<div className='w-full z-50 h-1/6 flex flex-row items-end justify-between px-3'>*/}
+			{/*	<dialog id='editTradePost_modal' className='modal'>*/}
+			{/*		<div className='modal-box rounded-xl'>*/}
+			{/*			<form action={editTradePost} className='px-2 flex flex-col gap-4 items-end size-full'>*/}
+			{/*				<label className='form-control size-full gap-4'>*/}
+			{/*					Edit this post:*/}
+			{/*					<input type='hidden' name='profileId' value={params.id}/>*/}
+			{/*					<input type='hidden' name='userId' value={session.data?.user.id!}/>*/}
+			{/*					<label className="input input-bordered flex items-center gap-2 rounded-xl">*/}
+			{/*						Title:*/}
+			{/*						<input type="text" name='title' className="grow" placeholder="Daisy"/>*/}
+			{/*					</label>*/}
+			{/*					<label className="input input-bordered flex items-center gap-2 rounded-xl">*/}
+			{/*						Image:*/}
+			{/*						<input type="text" name='image' className="grow" placeholder="daisy@site.com"/>*/}
+			{/*					</label>*/}
+			{/*					<textarea*/}
+			{/*						className='textarea textarea-bordered w-full h-24 resize-none rounded-xl whitespace-pre-line'*/}
+			{/*						name='description'*/}
+			{/*						placeholder='Provide a discription for your post...'></textarea>*/}
+			{/*					<label className="input input-bordered flex items-center gap-2 rounded-xl">*/}
+			{/*						Price:*/}
+			{/*						<input type="text" name='price' className="grow" placeholder="daisy@site.com"/>*/}
+			{/*					</label>*/}
+			{/*					<div className='flex flex-row items-center justify-evenly'>*/}
+			{/*						<div className="form-control">*/}
+			{/*							<label className="label cursor-pointer gap-4">*/}
+			{/*								<span className="label-text">Selling</span>*/}
+			{/*								<input type="radio" name="radio-10"*/}
+			{/*									   className="radio checked:bg-green-500"*/}
+			{/*									   checked/>*/}
+			{/*							</label>*/}
+			{/*						</div>*/}
+			{/*						<div className="form-control">*/}
+			{/*							<label className="label cursor-pointer gap-4">*/}
+			{/*								<span className="label-text">Buying</span>*/}
+			{/*								<input type="radio" name="radio-10" className="radio checked:bg-red-500"*/}
+			{/*									   checked/>*/}
+			{/*							</label>*/}
+			{/*						</div>*/}
+			{/*					</div>*/}
+			{/*				</label>*/}
+			{/*				<button*/}
+			{/*					className='btn btn-outline rounded-xl btn-sm'*/}
+			{/*					type='submit'*/}
+			{/*					onClick={() => {*/}
+			{/*						(document.getElementById('addTradePost_modal') as HTMLDialogElement).close();*/}
+			{/*						// mutate(url);*/}
+			{/*					}}>*/}
+			{/*					Submit*/}
+			{/*				</button>*/}
+			{/*			</form>*/}
+			{/*		</div>*/}
+			{/*		<form method='dialog' className='modal-backdrop'>*/}
+			{/*			<button>close</button>*/}
+			{/*		</form>*/}
+			{/*	</dialog>*/}
+			{/*	<div className='join'>*/}
+			{/*		<button className='join-item btn btn-sm btn-active'>1</button>*/}
+			{/*		<button className='join-item btn btn-sm'>2</button>*/}
+			{/*		<button className='join-item btn btn-sm'>3</button>*/}
+			{/*		<button className='join-item btn btn-sm'>4</button>*/}
+			{/*	</div>*/}
+			{/*</div>*/}
 		</div>
-	);
+);
 };
 
 export default Posts;

--- a/src/components/ui/DirectionAwareHover.tsx
+++ b/src/components/ui/DirectionAwareHover.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Image from 'next/image';
 import { AnimatePresence, motion } from 'framer-motion';
 import { cn } from '@/utils/cn';
@@ -59,7 +59,8 @@ export const DirectionAwareHover = ({
 			className={cn('bg-transparent rounded-lg overflow-hidden group/card relative h-full w-full', className)}>
 			<AnimatePresence mode='wait'>
 				<motion.div className='relative h-full w-full' initial='initial' whileHover={direction} exit='exit'>
-					<motion.div className='group-hover/card:block hidden absolute inset-0 w-full h-full bg-black/40 z-10 transition duration-200 ' />
+					<motion.div
+						className='group-hover/card:block hidden absolute inset-0 w-full h-full bg-black/40 z-10 transition duration-200 '/>
 					<motion.div
 						variants={variants}
 						className='h-full w-full relative bg-gray-50 dark:bg-black'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -68,4 +68,4 @@ export const editTradePostSchema = z.object({
 	userId: z.string().min(1, 'Require userId'),
 });
 
-export type TEditTradePostSchema = z.infer<typeof addTradePostSchema>;
+export type TEditTradePostSchema = z.infer<typeof editTradePostSchema>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -62,3 +62,10 @@ export type TTradePost = {
 	createdAt: string;
 	updatedAt: string;
 };
+
+export const editTradePostSchema = z.object({
+	profileId: z.string().min(1, 'Require profileId'),
+	userId: z.string().min(1, 'Require userId'),
+});
+
+export type TEditTradePostSchema = z.infer<typeof addTradePostSchema>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -69,3 +69,10 @@ export const editTradePostSchema = z.object({
 });
 
 export type TEditTradePostSchema = z.infer<typeof editTradePostSchema>;
+
+export const deleteTradePostSchema = z.object({
+	profileId: z.string().min(1, 'Require profileId'),
+	userId: z.string().min(1, 'Require userId'),
+});
+
+export type TDeleteTradePostSchema = z.infer<typeof deleteTradePostSchema>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -43,3 +43,28 @@ export type TComment = {
 		image: string;
 	};
 };
+
+export const addTradePostSchema = z.object({
+	profileId: z.string().min(1, 'Require profileId'),
+	userId: z.string().min(1, 'Require userId'),
+	title: z.string().min(1, 'Require title'),
+	description: z.string().min(1, 'Require description'),
+	price: z.string().min(1, 'Require price'),
+	postType: z.string().min(1, 'Require post type'),
+	image: z.string().min(1, 'Require image'),
+});
+
+export type TAddTradePostSchema = z.infer<typeof addTradePostSchema>;
+
+export type TTradePost = {
+	id: string;
+	title: string;
+	image: string;
+	description: string;
+	price: string;
+	postType: string
+	userId: string;
+	profileId: string;
+	createdAt: string;
+	updatedAt: string;
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -47,11 +47,6 @@ export type TComment = {
 export const addTradePostSchema = z.object({
 	profileId: z.string().min(1, 'Require profileId'),
 	userId: z.string().min(1, 'Require userId'),
-	title: z.string().min(1, 'Require title'),
-	description: z.string().min(1, 'Require description'),
-	price: z.string().min(1, 'Require price'),
-	postType: z.string().min(1, 'Require post type'),
-	image: z.string().min(1, 'Require image'),
 });
 
 export type TAddTradePostSchema = z.infer<typeof addTradePostSchema>;
@@ -64,7 +59,6 @@ export type TTradePost = {
 	price: string;
 	postType: string
 	userId: string;
-	profileId: string;
 	createdAt: string;
 	updatedAt: string;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,7 +6,7 @@ import z from 'zod';
 
 // SignUp form
 export const signUpSchema = z.object({
-	username: z.string().min(3, '3 characters min.').max(20, '20 characters max.'),
+	name: z.string().min(3, '3 characters min.').max(20, '20 characters max.'),
 	email: z.string().min(1, 'Email required.').email('Invalid email'),
 	password: z.string().min(1, 'Password required.').min(8, '8 characters min.'),
 });
@@ -38,4 +38,8 @@ export type TComment = {
 	createdAt: string;
 	updatedAt: string;
 	image: string;
+	user: {
+		name: string;
+		image: string;
+	};
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -59,8 +59,6 @@ export type TTradePost = {
 	price: string;
 	postType: string
 	userId: string;
-	createdAt: string;
-	updatedAt: string;
 };
 
 export const editTradePostSchema = z.object({


### PR DESCRIPTION
# Overview

Completed the adding and editing functionality of the Trade Posts tab.

## User Stories

- #18 

## Features

- Allows users to add new trade posts to their profile.
- Allows users to edit previously added trade posts on their profile.
- Allows the user to delete previously added trade posts on their profile.

## Changes

- Created a tradePosts table to the database.
- Created a form in a modal for adding and editing trade posts.
- Created functions to add, edit, and delete trade posts.

## Known Issues or Bugs

- Styling problems upon hover if the trade post has a long description.
- Separate form for edit should eventually be removed to use same form as the add new trade post form.
- Prop drilling.

## Snapshots
Add new trade post:
![AddNewTradePost](https://github.com/brandonhach/rep/assets/74819172/618186bc-13ea-4061-b46e-3ee8310aa934)

Edit trade post:
![EditTradePost](https://github.com/brandonhach/rep/assets/74819172/c2bea76e-288e-413e-a5cd-1dd21cc17013)

Delete trade post:
![DeleteTradePost](https://github.com/brandonhach/rep/assets/74819172/34d56eec-4fad-4f44-8133-c2e43da6630f)